### PR TITLE
Handle user groups safely in db.php

### DIFF
--- a/helper/db.php
+++ b/helper/db.php
@@ -203,7 +203,8 @@ class helper_plugin_approve_db extends Plugin
 
         if ($user !== '') {
             $user_data = $auth->getUserData($user);
-            $user_groups = $user_data['grps'];
+            // If export_pdf template contains @APPROVER@ prevent Error: Call to undefined method helper_plugin_approve_db::getDB()
+            $user_groups = isset($user_data['grps']) && is_array($user_data['grps']) ? $user_data['grps'] : [];
             $pages = array_filter($pages, function ($page) use ($user, $user_groups) {
                 return $page['approver'][0] == '@' && in_array(substr($page['approver'], 1), $user_groups) ||
                     $page['approver'] == $user;


### PR DESCRIPTION
Add check for user groups to prevent undefined method error. 

If export_pdf template contains `@APPROVER@` (thanks to approveplus plugin adding support via `dw2pdf template-tag @APPROVER@`) prevents Error when trying to render PDF: `Call to undefined method helper_plugin_approve_db::getDB().`

This is the same patch as was proposed for 2023 version https://github.com/gkrid/dokuwiki-plugin-approve/pull/50 but adapted to new structure of the plugin (ApproveMetadata.php logic moved to db.php)